### PR TITLE
DEVOPS-33945: pin external action SHAs

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -13,7 +13,7 @@ jobs:
       'args' input
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run action with args
@@ -30,7 +30,7 @@ jobs:
       'projectBaseDir' input
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: mkdir -p ./baseDir
@@ -49,7 +49,7 @@ jobs:
       Don't fail on Gradle project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run action on Gradle project
@@ -69,7 +69,7 @@ jobs:
       Don't fail on Kotlin Gradle project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run action on Kotlin Gradle project
@@ -89,7 +89,7 @@ jobs:
       Don't fail on Maven project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run action on Maven project
@@ -121,7 +121,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run action on sample project
@@ -140,7 +140,7 @@ jobs:
       'RUNNER_DEBUG' is used
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run action with debug mode
@@ -170,11 +170,11 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarQube Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ github.workspace }}/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Parse semver
-        uses: madhead/semver-utils@v4
+        uses: madhead/semver-utils@36d1e0ed361bd7b4b77665de8093092eaeabe6ba # v4.3.0
         id: version
         with:
           version: ${{ github.ref_name }}


### PR DESCRIPTION
## What

Replaces tag references for **external** GitHub Actions with the corresponding 40-char commit SHAs. The original tag is preserved as a trailing comment for readability.

Example:
```diff
- uses: actions/checkout@v4
+ uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
```

Applies to:
- `.github/workflows/*.yml` / `*.yaml`
- Composite `action.yml` / `action.yaml` files (at repo root and in subdirectories)

Only `uses:` references to **non-`letsdeel`** owners are pinned — internal reusable workflows and composite actions are left as-is.

## Why

Tag references like `@v4` and `@main` are **mutable**. The upstream action owner can repoint a tag at any time, including to malicious code, and every workflow run that consumes the tag will execute it on the next run. SHA pinning is GitHub's [recommended mitigation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and matches the org-wide hardening already completed in [`letsdeel/actions-templates`](https://github.com/letsdeel/actions-templates) under DEVOPS-33945.

## Safety

- Each SHA pinned here is the **current target of the tag** at the time this PR was opened → functionally a no-op for CI.
- Renovate / Dependabot, where configured, can keep SHAs updated automatically (`pinDigests` preset).
- Rewrite generated with [`pinact`](https://github.com/suzuki-shunsuke/pinact) and reviewed.

## Ticket
DEVOPS-33945: SHA Pinning for All GitHub Action Tags — Org-wide
